### PR TITLE
feat(ansible-semaphore): add support for existing secrets via envFrom…

### DIFF
--- a/charts/ansible-semaphore/Chart.yaml
+++ b/charts/ansible-semaphore/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ansible-semaphore
-version: 1.1.0
+version: 1.2.0
 appVersion: v2.10.22
 home: https://semaphoreui.com
 description: |

--- a/charts/ansible-semaphore/templates/deployment.yaml
+++ b/charts/ansible-semaphore/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.envFrom }}
-          {{- if or .Values.envFrom.configmaps .Values.envFrom.secrets .Values.envFrom.existingSecrets }}
+          {{- if or .Values.envFrom.configmaps .Values.envFrom.secrets .Values.existingSecrets }}
           envFrom:
             {{- if .Values.envFrom.configmaps }}
             - configMapRef:
@@ -73,7 +73,7 @@ spec:
             - secretRef:
                 name: {{ template "helmproj.fullname" . }}
             {{- end }}
-            {{- range .Values.envFrom.existingSecrets }}
+            {{- range .Values.existingSecrets }}
             - secretRef:
                 name: {{ . }}
             {{- end }}

--- a/charts/ansible-semaphore/templates/deployment.yaml
+++ b/charts/ansible-semaphore/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.envFrom }}
-          {{- if or .Values.envFrom.configmaps .Values.envFrom.secrets }}
+          {{- if or .Values.envFrom.configmaps .Values.envFrom.secrets .Values.envFrom.existingSecrets }}
           envFrom:
             {{- if .Values.envFrom.configmaps }}
             - configMapRef:
@@ -72,6 +72,10 @@ spec:
             {{- if .Values.envFrom.secrets }}
             - secretRef:
                 name: {{ template "helmproj.fullname" . }}
+            {{- end }}
+            {{- range .Values.envFrom.existingSecrets }}
+            - secretRef:
+                name: {{ . }}
             {{- end }}
           {{- end }}
           {{- end }}
@@ -84,7 +88,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if or .Values.volumeMounts.configmaps .Values.volumeMounts.secrets }}
+      {{- if and .Values.volumeMounts (or .Values.volumeMounts.configmaps .Values.volumeMounts.secrets) }}
       volumes:
         {{- if .Values.volumeMounts.configmaps }}
         - name: configs

--- a/charts/ansible-semaphore/values.yaml
+++ b/charts/ansible-semaphore/values.yaml
@@ -27,11 +27,14 @@ image:
 #     TEST: true
 #   secrets:
 #     FOO: "supersecret"
+#   existingSecrets:
+#     - my-external-secret
+#     - another-existing-secret
 
 volumeMountsPath:
   configmaps: /configmaps
   secrets: /secrets
-  
+
 # volumeMounts:
 #   configmaps:
 #     config.yaml: |
@@ -49,7 +52,6 @@ volumeMountsPath:
 #   DATABASE_PATH: "/var/lib/semaphore/database.boltdb"
 #   DATABASE_PORT: null
 #   DATABASE_USERNAME: "semaphore"
-
 
 imagePullSecrets: []
 nameOverride: ""
@@ -120,7 +122,7 @@ autoscaling:
 
 test:
   enabled: false
-  
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/ansible-semaphore/values.yaml
+++ b/charts/ansible-semaphore/values.yaml
@@ -27,9 +27,10 @@ image:
 #     TEST: true
 #   secrets:
 #     FOO: "supersecret"
-#   existingSecrets:
-#     - my-external-secret
-#     - another-existing-secret
+
+# existingSecrets:
+#   - my-external-secret
+#   - another-existing-secret
 
 volumeMountsPath:
   configmaps: /configmaps


### PR DESCRIPTION
….existingSecrets

Allow users to reference pre-existing secrets (e.g. created manually or via External Secrets Operator) through the new `envFrom.existingSecrets` list. Each entry is rendered as a `secretRef` in the deployment's `envFrom` block, loading all keys from the referenced secret as environment variables.

Bumps chart version to 1.2.0.